### PR TITLE
Prevent cosmiconfig to read package.json "svelte" property

### DIFF
--- a/src/plugins/SveltePlugin.ts
+++ b/src/plugins/SveltePlugin.ts
@@ -64,7 +64,9 @@ export class SveltePlugin implements DiagnosticsProvider {
 
     private async loadConfig(path: string): Promise<SvelteConfig> {
         try {
-            const { config } = await cosmic('svelte').load(path);
+            const { config } = await cosmic('svelte', {
+                packageProp: false   
+            }).load(path);
             return { ...DEFAULT_OPTIONS, ...config };
         } catch (err) {
             return { ...DEFAULT_OPTIONS, preprocess: {} };


### PR DESCRIPTION
The package.json `svelte` property usually defines a svelte component, not a svelte config.