### PR TITLE
Add basic support for Svelte v3

### DIFF
--- a/src/plugins/SveltePlugin.ts
+++ b/src/plugins/SveltePlugin.ts
@@ -51,9 +51,10 @@ export class SveltePlugin implements DiagnosticsProvider {
 
         let diagnostics: Diagnostic[];
         try {
+            delete config.preprocess;
             const res = svelte.compile(source, config);
 
-            diagnostics = (res.stats.warnings as Warning[]).map(warning => {
+            diagnostics = ((res.stats.warnings || res.warnings || []) as Warning[]).map(warning => {
                 const start = warning.start || { line: 1, column: 0 };
                 const end = warning.end || start;
                 return {


### PR DESCRIPTION
I've found a couple of issues when using svelte-vscode with Svelte 3 (specifically the [sapper v3 template]). This is basic support to get the extension to not throw errors; there's probably a lot to to to support the new syntax as detailed in [the RFCs].

[sapper v3 template]: https://github.com/sveltejs/sapper-template/tree/rollup-v3
[the RFCs]: https://github.com/sveltejs/rfcs/tree/master/text

Here are the fixes:

- Don't pass `preprocess` option to the compiler
- Handle new `warnings` location

And the relevant upstream changes:

- sveltejs/svelte#2095
- sveltejs/svelte#2102

Fixes UnwrittenFun/svelte-vscode#33

Please let me know if there's a different way you want to handle the changes for v3, and if there are any tests you want me to add.