### PR TITLE
fix: @apply issue. Don't do validation on postcss

### DIFF
--- a/src/plugins/CSSPlugin.ts
+++ b/src/plugins/CSSPlugin.ts
@@ -75,9 +75,15 @@ export class CSSPlugin
             return [];
         }
 
-        return getLanguageService(extractLanguage(document))
+        const kind = extractLanguage(document);
+
+        if (shouldExcludeValidation(kind)) {
+            return [];
+        }
+
+        return getLanguageService(kind)
             .doValidation(document, stylesheet)
-            .map(diagnostic => ({ ...diagnostic, source: 'css' }));
+            .map(diagnostic => ({ ...diagnostic, source: getLanguage(kind) }));
     }
 
     doHover(document: Document, position: Position): Hover | null {
@@ -206,6 +212,16 @@ function getLanguage(kind?: string) {
         case 'text/css':
         default:
             return 'css';
+    }
+}
+
+function shouldExcludeValidation(kind?: string) {
+    switch (kind) {
+        case 'postcss':
+        case 'text/postcss':
+            return true;
+        default:
+            return false;
     }
 }
 


### PR DESCRIPTION
Related to this issue https://github.com/UnwrittenFun/svelte-vscode/issues/47

Made a PR so that we can use `@apply` on `<style type="type/postcss">` While still preservering css validation on regular css