### PR TITLE
Work around slow Typescript compilation by debouncing diagnostics calls on documentChange events

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { HTMLPlugin } from './plugins/HTMLPlugin';
 import { CSSPlugin } from './plugins/CSSPlugin';
 import { wrapFragmentPlugin } from './api/wrapFragmentPlugin';
 import { TypeScriptPlugin } from './plugins/TypeScriptPlugin';
+import _ from 'lodash';
 
 namespace TagCloseRequest {
     export const type: RequestType<
@@ -114,13 +115,16 @@ export function startServer() {
         manager.getCodeActions(evt.textDocument, evt.range, evt.context),
     );
 
-    manager.on('documentChange', async document => {
-        const diagnostics = await manager.getDiagnostics({ uri: document.getURL() });
-        connection.sendDiagnostics({
-            uri: document.getURL(),
-            diagnostics,
-        });
-    });
+    manager.on(
+        'documentChange',
+        _.debounce(async document => {
+            const diagnostics = await manager.getDiagnostics({ uri: document.getURL() });
+            connection.sendDiagnostics({
+                uri: document.getURL(),
+                diagnostics,
+            });
+        }, 500),
+    );
 
     connection.listen();
 }


### PR DESCRIPTION
As reported in https://github.com/UnwrittenFun/svelte-vscode/issues/65, each keystroke triggers a separate call to validate typescript (and presumably any other preprocessors). Debouncing the `documentChange` handler makes everything much smoother and more stable feeling.

![before](https://user-images.githubusercontent.com/49615/63213501-1ee1dc00-c0db-11e9-9e8f-7ac81de57eed.png)
![after](https://user-images.githubusercontent.com/49615/63213502-230df980-c0db-11e9-8dae-30697e11d918.png)

I played with a few durations. Smaller can feel a bit snappier, but it's also more likely to collide with a slow compile and start piling up requests again. Open to ideas! I think a slightly more sophisticated queue could be even better.

There also seems to be some stuff around cancelling events in the LSP protocol, but I'm not familiar enough to know if that's relevant. This solution is imperfect, but it seems like a very workable stopgap.

Thanks!