### PR TITLE
Only autocomplete on correct css characters

### DIFF
--- a/src/plugins/CSSPlugin.ts
+++ b/src/plugins/CSSPlugin.ts
@@ -36,6 +36,8 @@ export class CSSPlugin
         DocumentColorsProvider,
         ColorPresentationsProvider,
         DocumentSymbolsProvider {
+    private readonly triggerCharacters = ['/'];
+            
     public static matchFragment(fragment: Fragment) {
         return fragment.details.attributes.tag == 'style';
     }
@@ -103,7 +105,11 @@ export class CSSPlugin
         );
     }
 
-    getCompletions(document: Document, position: Position): CompletionList | null {
+    getCompletions(document: Document, position: Position, triggerCharacter: string): CompletionList | null {
+        if (triggerCharacter != undefined && !this.triggerCharacters.includes(triggerCharacter)) {
+            return null;
+        }
+        
         if (!this.host.getConfig<boolean>('css.completions.enable')) {
             return null;
         }


### PR DESCRIPTION
Right now if you are in the <style> or css context of a svelte file and press space it will try to autocomplete. This is pretty annoying and breaks the flow of coding.

This is the only trigger characters that vscode provides for css
https://github.com/microsoft/vscode/blob/eeab6fc371fcbfead7a1bd887c28f7efb28e5fcb/extensions/css-language-features/server/src/cssServerMain.ts#L131