### PR TITLE
add stdio support

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -25,7 +25,7 @@ namespace TagCloseRequest {
 }
 
 export function startServer() {
-    const connection = createConnection(
+    const connection = process.argv.includes('--stdio') ? createConnection(process.stdin, process.stdout) : createConnection(
         new IPCMessageReader(process),
         new IPCMessageWriter(process),
     );


### PR DESCRIPTION
Adds support for stdio. Not all lsp clients support nodejs ipc (example: [lsp-mode](https://github.com/emacs-lsp/lsp-mode) for emacs) but this language server only supports ipc and because of that you can't use it with clients that don't support it. IPC is still used unless you start the server with `--stdio` so all existing editor extensions will still function normally.